### PR TITLE
Disable skip step verification in export mode.

### DIFF
--- a/grail/steps.py
+++ b/grail/steps.py
@@ -52,6 +52,8 @@ class _RedirectOut(object):
 def _should_skip_step():
     if settings.disable_steps:
         return True
+    if settings.export_mode:
+        return False
     for filename, line_number, func_name, text in traceback.extract_stack():
         if func_name in settings.skip_func:
             return True
@@ -72,7 +74,7 @@ def _validate_step_info(step_info):
 
 
 def _execute(step_info):
-    if not settings.export_mode and _should_skip_step():
+    if _should_skip_step():
         return step_info.run_function()
 
     redirected_out = _RedirectOut()

--- a/grail/steps.py
+++ b/grail/steps.py
@@ -72,7 +72,7 @@ def _validate_step_info(step_info):
 
 
 def _execute(step_info):
-    if _should_skip_step():
+    if not settings.export_mode and _should_skip_step():
         return step_info.run_function()
 
     redirected_out = _RedirectOut()


### PR DESCRIPTION
This change greatly improves export mode performance on a large amount of tests. I have 5 vs. 13 seconds on 10K tests.