### PR TITLE
Do not remove 'self' within format_description to keep everything consistent

### DIFF
--- a/grail/step_info.py
+++ b/grail/step_info.py
@@ -63,8 +63,7 @@ class StepInfo(object):
         else:
             message += result + ' '
         if self.format_description:
-            args, kwargs = self._get_clean_params()
-            message += self.description.format(*args, **kwargs)
+            message += self.description.format(*self.args, **self.kwargs)
         else:
             message += self.description or self._get_name_based_description()
             if self.log_input:


### PR DESCRIPTION
Common case when data becomes inconsistent and I have to write my own dirty hooks to make it work, because otherwise it's IndexError.
```
url = '/api/id/{1}'

class SomeClass(object)

    @api_method(path=url)
    def get_something(self, id, **kwargs):
        return api_get_request(self.get_something, **kwargs)

class SomeStepClass(object):

    @step(description=url, format_description=True)
    def step_get_something(self, id):
        return SomeClass().get_something(id)
```